### PR TITLE
Package traits.yml as package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include traits.yml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = ["openassetio>=1.0.0a6"]
 
 [tool.setuptools]
 packages = ["openassetio_mediacreation"]
+include_package_data=True
 
 [project.urls]
 Source = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ dependencies = ["openassetio>=1.0.0a6"]
 
 [tool.setuptools]
 packages = ["openassetio_mediacreation"]
-include_package_data=True
 
 [project.urls]
 Source = "https://github.com/OpenAssetIO/OpenAssetIO-MediaCreation"

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
     cmdclass={
         "build_py": GenerateThenBuild,
     },
+    include_package_data=True,
 )

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,6 @@
 # Copyright 2013-2022 The Foundry Visionmongers Ltd
 from distutils.command.build_py import build_py
 import logging
-import os
-from shutil import copyfile
 from setuptools import setup
 
 import openassetio_traitgen
@@ -23,11 +21,6 @@ class GenerateThenBuild(build_py):
             logging.Logger("openassetio-mediacreation-traitgen"),
             False,
             None,
-        )
-
-        # Move the source trait yaml to the package directory.
-        copyfile(
-            "traits.yml", os.path.join(self.build_lib, "openassetio_mediacreation", "traits.yml")
         )
 
         build_py.run(self)

--- a/tests/python/openassetio_mediacreation/test_packaging.py
+++ b/tests/python/openassetio_mediacreation/test_packaging.py
@@ -11,6 +11,7 @@ Test the package is generated as we expect
 
 import site
 from pathlib import Path
+import os
 import pytest
 
 
@@ -26,6 +27,12 @@ class Test_packaging:
         package_dir = Path(site_packages_dir) / "openassetio_mediacreation"
 
         assert package_dir.exists()
+
+        files = os.listdir(package_dir)
+
+        # Print the files
+        for file in files:
+            print(file)
 
         # Check if the traits.yml file exists in the package directory
         traits_file = package_dir / "traits.yml"

--- a/tests/python/openassetio_mediacreation/test_packaging.py
+++ b/tests/python/openassetio_mediacreation/test_packaging.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 The Foundry Visionmongers Ltd
+"""
+Test the package is generated as we expect
+"""
+
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-import,import-outside-toplevel
+# pylint: disable=missing-class-docstring,missing-function-docstring
+
+import site
+from pathlib import Path
+import pytest
+
+
+class Test_packaging:
+    def test_traits_file_is_present(self):
+        # Verify the package is installed
+        import openassetio_mediacreation
+
+        # Find the site-packages directory for the current interpreter
+        site_packages_dir = site.getsitepackages()[0]
+
+        # Build path to the openassetio-mediacreation package directory
+        package_dir = Path(site_packages_dir) / "openassetio_mediacreation"
+
+        # Check if the traits.yml file exists in the package directory
+        traits_file = package_dir / "traits.yml"
+        assert traits_file.exists()

--- a/tests/python/openassetio_mediacreation/test_packaging.py
+++ b/tests/python/openassetio_mediacreation/test_packaging.py
@@ -9,8 +9,6 @@ Test the package is generated as we expect
 # pylint: disable=unused-import,import-outside-toplevel
 # pylint: disable=missing-class-docstring,missing-function-docstring
 
-import site
-from pathlib import Path
 import os
 import pytest
 
@@ -20,20 +18,9 @@ class Test_packaging:
         # Verify the package is installed
         import openassetio_mediacreation
 
-        # Find the site-packages directory for the current interpreter
-        site_packages_dir = site.getsitepackages()[0]
+        # Find traits file in the mediacreation install
+        traits_file = os.path.join(
+            os.path.dirname(openassetio_mediacreation.__file__), "traits.yml"
+        )
 
-        # Build path to the openassetio-mediacreation package directory
-        package_dir = Path(site_packages_dir) / "openassetio_mediacreation"
-
-        assert package_dir.exists()
-
-        files = os.listdir(package_dir)
-
-        # Print the files
-        for file in files:
-            print(file)
-
-        # Check if the traits.yml file exists in the package directory
-        traits_file = package_dir / "traits.yml"
-        assert traits_file.exists()
+        assert os.path.exists(traits_file)

--- a/tests/python/openassetio_mediacreation/test_packaging.py
+++ b/tests/python/openassetio_mediacreation/test_packaging.py
@@ -25,6 +25,8 @@ class Test_packaging:
         # Build path to the openassetio-mediacreation package directory
         package_dir = Path(site_packages_dir) / "openassetio_mediacreation"
 
+        assert package_dir.exists()
+
         # Check if the traits.yml file exists in the package directory
         traits_file = package_dir / "traits.yml"
         assert traits_file.exists()


### PR DESCRIPTION
Rather than a manual copy, do "the right thing" and package traits.yml via use of a manifest file.

Adds a test to verify that this file exists in a deployment.