### PR TITLE
[Build] Add hybrid python generation to cmake.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,3 +68,34 @@ jobs:
 
       - name: Test
         run: ctest -VV --test-dir build/tests/cpp --parallel 2
+
+  test-python-from-cmake:
+  # To support hybrid C++ applications, the python package may also be
+  # generated using the CMake packaging, in addition and simultaneously
+  # to the C++ package. This tests that.
+    name: "Test-Python-From-CMake"
+    runs-on: ubuntu-latest
+    container:
+      image: aswf/ci-vfxall:2022-clang14.3
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Traitgen
+        run: python -m pip install openassetio-traitgen==1.0.0a6
+
+      - name: Configure CMake build
+        run: >
+          cmake -S . -B build -G Ninja
+          -DOPENASSETIO_MEDIACREATION_GENERATE_PYTHON=ON
+          -DOPENASSETIO_MEDIACREATION_PYTHON_SITEDIR="hybridpython"
+
+      - name: Install package
+        run: cmake --install build
+
+      - name: Install OpenAssetIO
+        run: python -m pip install openassetio>=1.0.0a6
+
+      - name: Test
+        run: |
+          python -m pip install -r tests/python/requirements.txt
+          PYTHONPATH=$(pwd)/build/dist/hybridpython python -m pytest -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,18 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 #-----------------------------------------------------------------------
 # Options
 option(OPENASSETIO_MEDIACREATION_ENABLE_TEST "Run test on mediacreation traits" OFF)
+option(OPENASSETIO_MEDIACREATION_GENERATE_PYTHON "Aditionally generate python library" OFF)
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    # By default we'll compute the correct site-packages directory
+    # structure, but allow overriding.
+    set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR
+        ""
+        CACHE STRING
+        "Override default Python module install directory, relative to CMAKE_INSTALL_PREFIX")
+endif ()
+
 message(STATUS "Test enabled = ${OPENASSETIO_MEDIACREATION_ENABLE_TEST}")
+message(STATUS "Generate python library = ${OPENASSETIO_MEDIACREATION_GENERATE_PYTHON}")
 
 # ABI wrangling only needed for test
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND
@@ -65,6 +76,13 @@ execute_process(COMMAND openassetio-traitgen ${PROJECT_BINARY_DIR}/traits.yml
                 COMMAND_ERROR_IS_FATAL ANY
                 COMMAND_ECHO STDERR)
 
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    execute_process(COMMAND openassetio-traitgen ${PROJECT_BINARY_DIR}/traits.yml
+    -o ${PROJECT_BINARY_DIR}/package -g python
+    COMMAND_ERROR_IS_FATAL ANY
+    COMMAND_ECHO STDERR)
+endif()
+
 add_library(openassetio-mediacreation INTERFACE)
 # add alias so the project can be used with add_subdirectory
 add_library(OpenAssetIO-MediaCreation::openassetio-mediacreation ALIAS openassetio-mediacreation)
@@ -111,6 +129,18 @@ install(
     NAMESPACE ${PROJECT_NAME}::
     FILE ${PROJECT_NAME}Targets.cmake
 )
+
+#-----------------------------------------------------------------------
+# Optionally install python library
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    include(ThirdParty)
+
+    install(
+        DIRECTORY ${PROJECT_BINARY_DIR}/package/openassetio_mediacreation
+        DESTINATION "${OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR}"
+        FILES_MATCHING PATTERN "*.py"
+    )
+endif()
 
 #-----------------------------------------------------------------------
 # Copy CMake Files

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,15 @@
 Release Notes
 =============
 
+v1.0.0-alpha.x
+--------------
+### New Features
+
+- Added ability to generate python package whilst installing via cmake
+  build system.
+  Added cmake variables `OPENASSETIO_MEDIACREATION_GENERATE_PYTHON` and
+  `OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR` to support this.
+
 v1.0.0-alpha.6
 --------------
 

--- a/cmake/ThirdParty.cmake
+++ b/cmake/ThirdParty.cmake
@@ -1,0 +1,44 @@
+#-----------------------------------------------------------------------
+# Python
+
+if (OPENASSETIO_MEDIACREATION_GENERATE_PYTHON)
+    #-------------------------------------------------------------------
+    # Locate packages
+
+    # Locate the Python package.
+    find_package(Python REQUIRED COMPONENTS Interpreter)
+
+    # Debug log some outputs expected from the built-in FindPython.
+    message(TRACE "Python_EXECUTABLE = ${Python_EXECUTABLE}")
+    message(TRACE "Python_INTERPRETER_ID = ${Python_INTERPRETER_ID}")
+    message(TRACE "Python_STDLIB = ${Python_STDLIB}")
+    message(TRACE "Python_STDARCH = ${Python_STDARCH}")
+    message(TRACE "Python_SITELIB = ${Python_SITELIB}")
+    message(TRACE "Python_SITEARCH = ${Python_SITEARCH}")
+    message(TRACE "Python_SOABI = ${Python_SOABI}")
+    message(TRACE "Python_INCLUDE_DIRS = ${Python_INCLUDE_DIRS}")
+    message(TRACE "Python_LINK_OPTIONS = ${Python_LINK_OPTIONS}")
+    message(TRACE "Python_LIBRARIES = ${Python_LIBRARIES}")
+    message(TRACE "Python_LIBRARY_DIRS = ${Python_LIBRARY_DIRS}")
+    message(TRACE "Python_RUNTIME_LIBRARY_DIRS = ${Python_RUNTIME_LIBRARY_DIRS}")
+    message(TRACE "Python_VERSION = ${Python_VERSION}")
+    message(TRACE "Python_VERSION_MAJOR = ${Python_VERSION_MAJOR}")
+    message(TRACE "Python_VERSION_MINOR = ${Python_VERSION_MINOR}")
+    message(TRACE "Python_VERSION_PATCH = ${Python_VERSION_PATCH}")
+
+    if (OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR STREQUAL "")
+        # Make a naive assumption about a suitable structure under our
+        # install-dir. See:
+        #   https://discuss.python.org/t/understanding-site-packages-directories/12959
+        # We had issues using 'cleverness' to work out the path relative
+        # to Python_EXECUTABLE and Python_SITEARCH when symlinks or
+        # varying installation structures were used (eg GitHub Actions
+        # runners).
+        if (WIN32) # Should not use 'bin' for Windows
+            set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR "Lib/site-packages")
+        else ()
+            set(OPENASSETIO_MEDIACREATION_PYTHON_SITEDIR
+                "lib/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages")
+        endif ()
+    endif ()
+endif()


### PR DESCRIPTION
[#49]
Adds the ability to optionally and additionally generate the python package when running under the cmake build system.

This is intended to enable hybrid hosts/managers to get both of their required libraries out without needing to call out/synchronize between multiple build systems (cmake & pip)